### PR TITLE
     Fixed "Export Animation" action not saving files.

### DIFF
--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -661,7 +661,7 @@ static void procedural_panel(goxel_t *goxel)
             mesh_clear(goxel->image->active_layer->mesh);
             proc_start(proc, NULL);
             gui->prog_export_animation = true;
-            sprintf(gui->prog_export_animation_path, "Path: %s", dir_path);
+            sprintf(gui->prog_export_animation_path, "%s", dir_path);
         }
     }
 


### PR DESCRIPTION
The "export animation" function is broken in v0.5.0 and master branches because in gui.c, the directory the user selects is prepended by "Path: ".

The bad prepend was removed to fix the problem.