### PR TITLE
SCons: Append external environment flags

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -121,4 +121,11 @@ if sound:
     env.Append(LIBS='openal')
     env.Append(CCFLAGS='-DSOUND=OPENAL')
 
+# Append external environment flags
+env.Append(
+    CFLAGS=os.environ.get("CFLAGS", "").split(),
+    CXXFLAGS=os.environ.get("CXXFLAGS", "").split(),
+    LINKFLAGS=os.environ.get("LDFLAGS", "").split()
+)
+
 env.Program(target='goxel', source=sources)


### PR DESCRIPTION
Those are typically use by Linux distro packagers to enforce their flag policies,
e.g. for Mageia:
```
CFLAGS="${CFLAGS:--O2 -g -pipe -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector --param=ssp-buffer-size=4}" ; export CFLAGS ;
CXXFLAGS="${CXXFLAGS:--O2 -g -pipe -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector --param=ssp-buffer-size=4}" ; export CXXFLAGS ;
FFLAGS="${FFLAGS:--O2 -g -pipe -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector --param=ssp-buffer-size=4}" ; export FFLAGS ;
LDFLAGS="${LDFLAGS:- -Wl,--as-needed -Wl,--no-undefined -Wl,-z,relro -Wl,-O1 -Wl,--build-id -Wl,--enable-new-dtags}" ; export LDFLAGS
```