### PR TITLE
Fix build on FreeBSD (and probably other *BSD)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 *~
 *.obj
 .sconsign.dblite
+/.sconf_temp
 /goxel
+/imgui.ini
+/config.log
 .DS_Store
 xcuserdata/

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ About
 -----
 
 You can use goxel to create voxel graphics (3D images formed of cubes).  It
-works on Linux, Windows and OSX
+works on Linux, BSD, Windows and macOS.
 
 
 Download
@@ -25,7 +25,7 @@ Download
 The last release files can be downloaded from [there](
 https://github.com/guillaumechereau/goxel/releases/latest).
 
-There is also in iOS version on [iTune](
+There is also in iOS version on [iTunes](
 https://itunes.apple.com/us/app/goxel-3d-voxel-editor/id1259097826).
 
 
@@ -70,7 +70,7 @@ release with 'scons debug=0'.  On Windows, I only tried to build with msys2.
 The code is in C99, using some gnu extensions, so it does not compile with
 msvc.
 
-# Linux
+# Linux/BSD
 
 Install dependencies: scons pkg-config libglfw3-dev libgtk-3-dev
 

--- a/SConstruct
+++ b/SConstruct
@@ -29,9 +29,12 @@ if clang:
 # Asan & Ubsan (need to come first).
 if debug and target_os == 'posix':
     env.Append(CCFLAGS=['-fsanitize=address', '-fsanitize=undefined'],
-               LIBS=['asan', 'ubsan'])
+               LINKFLAGS=['-fsanitize=address', '-fsanitize=undefined'])
+    if not clang:
+        env.Append(LIBS=['asan', 'ubsan'])
 
-env.Append(CFLAGS= '-Wall -std=gnu99 -Wno-unknown-pragmas',
+env.Append(CFLAGS= '-Wall -std=gnu99 -Wno-unknown-pragmas '
+                   '-Wno-unknown-warning-option',
            CXXFLAGS='-std=gnu++11 -Wall -Wno-narrowing '
                     '-Wno-unknown-pragmas -Wno-unused-function'
         )
@@ -56,6 +59,8 @@ sources = glob.glob('src/*.c') + glob.glob('src/*.cpp') + \
 
 if target_os == 'posix':
     env.Append(LIBS=['GL', 'm', 'z'])
+    if not conf.CheckDeclaration('__GLIBC__', includes='#include <features.h>'):
+        env.Append(LIBS=['argp'])
     # Note: add '--static' to link with all the libs needed by glfw3.
     env.ParseConfig('pkg-config --libs glfw3')
 

--- a/src/system.c
+++ b/src/system.c
@@ -22,7 +22,7 @@
 #include <dirent.h>
 #include <errno.h>
 
-#ifdef __linux__
+#ifdef __unix__
 #define NOC_FILE_DIALOG_GTK
 #define NOC_FILE_DIALOG_IMPLEMENTATION
 #include "noc_file_dialog.h"
@@ -94,7 +94,7 @@ GLuint sys_get_screen_framebuffer(void)
     return 0;
 }
 
-#ifdef __linux__
+#ifdef __unix__
 
 #include <gtk/gtk.h>
 


### PR DESCRIPTION
- instead of `-lasan -lubsan`, pass the sanitize flags to the final linking command, clang links these libraries automatically (and knows their actual location and name)
- ignore the unknown-warning-option warning from clang 5.0.0
- link to argp when libc is not glibc (might also help on musl systems like Alpine Linux?)
- check for `__unix__` instead of `__linux__` for GTK

Recent gcc is also [supposed to](https://gcc.gnu.org/onlinedocs/gcc/Link-Options.html#index-static-libasan) automatically link `asan`/`ubsan` provided `-fsanitize` flags, but gcc 5.x doesn't, so keeping `-lasan -lubsan` for non-clang.