### PR TITLE
Add snap package creation support

### DIFF
--- a/snap/gui/goxel.desktop
+++ b/snap/gui/goxel.desktop
@@ -1,6 +1,9 @@
 [Desktop Entry]
+Version=1.0
 Encoding=UTF-8
 Name=goxel
+Comment=3D Voxel Editor
 Exec=goxel
 Icon=${SNAP}/icon.png
 Type=Application
+Categories=Graphics;

--- a/snap/gui/goxel.desktop
+++ b/snap/gui/goxel.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Encoding=UTF-8
+Name=goxel
+Exec=goxel
+Icon=${SNAP}/icon.png
+Type=Application

--- a/snap/setup/goxel.desktop
+++ b/snap/setup/goxel.desktop
@@ -1,6 +1,0 @@
-[Desktop Entry]
-Encoding=UTF-8
-Name=goxel
-Exec=goxel
-Icon=${SNAP}/icon.png
-Type=Application

--- a/snap/setup/goxel.desktop
+++ b/snap/setup/goxel.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Encoding=UTF-8
+Name=goxel
+Exec=goxel
+Icon=${SNAP}/icon.png
+Type=Application

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -24,6 +24,7 @@ parts:
       make release
     install: |
       cp goxel $SNAPCRAFT_PART_INSTALL
+      cp icon.png $SNAPCRAFT_PART_INSTALL
     source-tag: 'v0.7.1'
     build-packages:
       - scons

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -25,7 +25,6 @@ parts:
     install: |
       cp goxel $SNAPCRAFT_PART_INSTALL
       cp icon.png $SNAPCRAFT_PART_INSTALL
-    source-tag: 'v0.7.1'
     build-packages:
       - scons
       - pkg-config

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,32 @@
+name: goxel
+version: git
+summary: Goxel. Free and Open Source 3D Voxel Editor
+description: |
+  You can use goxel to create voxel graphics (3D images formed of cubes). 
+  It works on Linux, BSD, Windows and macOS.
+
+confinement: strict
+
+apps:
+  goxel:
+    command: desktop-launch $SNAP/goxel
+    plugs:
+      - x11
+      - opengl
+      - home
+
+parts:
+  goxel:
+    after: [desktop-gtk3]
+    source: .
+    plugin: make
+    build: |
+      make release
+    install: |
+      cp goxel $SNAPCRAFT_PART_INSTALL
+    source-tag: 'v0.7.1'
+    build-packages:
+      - scons
+      - pkg-config
+      - libglfw3-dev
+      - libgtk-3-dev

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -31,3 +31,4 @@ parts:
       - pkg-config
       - libglfw3-dev
       - libgtk-3-dev
+      - libpng12-dev


### PR DESCRIPTION
Hi! I recently discovered goxel, and while I lack the artistic talent to create really great voxel based images, it's a great app!

I noticed that you don't have native linux packages, so I thought I'd add support for snap packages. Snaps are universal packages for multiple Linux distributions. With this pull request, you can build a snap of goxel and provide it automatically to millions of users via the snap store. A single snap works on Ubuntu LTS releases (14.04, 16.04) and interim releases (17.04, upcoming 17.10), Debian, Fedora, and more.

We have a command line tool called snapcraft which can be used to build the snap (which is how I built a snap and tested on my Ubuntu 16.04 system). We also have a free [build servic](http://build.snapcraft.io/)e you can hook up to this github repo, and build automatically on each commit, uploading to the store with each change.

If you accept this PR, then simply create an account in the snap store at http://dashboard.snapcraft.io, register your new snap 'goxel' and then use http://build.snapcraft.io to hook up github to the store, and you're done.

Builds will land in the edge channel on every commit, for adventurous users. When you create a stable release, you can push that to the stable channel for more conservative users.

This is all documented at http://snapcraft.io/docs but I'm happy to answer any questions here, on irc (popey), telegram (popeydc) or email (alan.pope@canonical.com).

Thanks!