### PR TITLE
Fix for text format output when there are leading zeros on a colour component

### DIFF
--- a/src/formats/txt.c
+++ b/src/formats/txt.c
@@ -18,6 +18,15 @@
 
 #include "goxel.h"
 
+static void print_colour_component(FILE *out, const uint8_t cpt)
+{
+    if (cpt < 0x10) {
+        fprintf(out, "0%1x", cpt);
+    } else {
+        fprintf(out, "%2x", cpt);
+    }
+}
+
 static void export_as_txt(const char *path)
 {
     FILE *out;
@@ -39,8 +48,11 @@ static void export_as_txt(const char *path)
     while (mesh_iter(&iter, p)) {
         mesh_get_at(mesh, &iter, p, v);
         if (v[3] < 127) continue;
-        fprintf(out, "%d %d %d %2x%2x%2x\n",
-                p[0], p[1], p[2], v[0], v[1], v[2]);
+        fprintf(out, "%d %d %d ", p[0], p[1], p[2]);
+        print_colour_component(out, v[0]);
+        print_colour_component(out, v[1]);
+        print_colour_component(out, v[2]);
+        fprintf(out, "\n");
     }
     fclose(out);
 }
@@ -54,4 +66,3 @@ ACTION_REGISTER(export_as_txt,
         .ext = "*.txt\0",
     },
 )
-


### PR DESCRIPTION
This commit ensures that the leading 0 of a colour component is printed in the text format
This means that a line with colour 0x98a107 is currently printed

    -24 -24 0 98a1 7

This commit ensures the leading zero on the blue component is printed, giving

    -24 -24 0 98a107