### PR TITLE
Fix typo in ply format name

### DIFF
--- a/index.markdown
+++ b/index.markdown
@@ -35,7 +35,7 @@ Open Source 3D voxel editor for Mac Windows and Linux.
 {% include feature.html
    title="Many export formats"
    icon="fa-file-image-o"
-   text="Goxel can export to obj, pyl, magica voxel, png, qubicle, povray,
+   text="Goxel can export to obj, ply, magica voxel, png, qubicle, povray,
          and more."
 %}
 


### PR DESCRIPTION
Hello,

A member of the Debian french l10n team noticed a typo in the description of the package `goxel` that is also present in goxel's website. Here's a merge request to fix it.

Thanks for making goxel!
Thomas