### PR TITLE
drag&drop and qb file type check

### DIFF
--- a/doc/cla/individual/sariug.md
+++ b/doc/cla/individual/sariug.md
@@ -1,0 +1,11 @@
+Turkey, 2020-03-02
+
+I hereby agree to the terms of the Goxel Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+sariug ugurcansari93@gmail.com https://github.com/sariug

--- a/src/formats/qubicle.c
+++ b/src/formats/qubicle.c
@@ -56,6 +56,12 @@ static void qubicle_import(const char *path)
                                         NULL, NULL, NULL);
     if (!path) return;
 
+    if (!str_endswith(path,".qb"))
+    {
+        gui_alert("Import Error", "Wrong type: This is not a .qb file");
+        return;
+    }
+
     file = fopen(path, "rb");
     version = READ(uint32_t, file);
     (void)version;

--- a/src/main.c
+++ b/src/main.c
@@ -38,6 +38,12 @@ void on_char(GLFWwindow *win, unsigned int c)
     inputs_insert_char(g_inputs, c);
 }
 
+void on_drop(GLFWwindow* win, int count, const char** paths)
+{
+    for (int i = 0;  i < count;  i++)
+        action_exec2("import", "p", paths[i]);
+}
+
 typedef struct
 {
     char *input;
@@ -293,6 +299,7 @@ int main(int argc, char **argv)
     glfwMakeContextCurrent(window);
     if (!DEFINED(EMSCRIPTEN))
         glfwSetScrollCallback(window, on_scroll);
+    glfwSetDropCallback(window, on_drop);
     glfwSetCharCallback(window, on_char);
     glfwSetInputMode(window, GLFW_STICKY_MOUSE_BUTTONS, false);
     set_window_icon(window);


### PR DESCRIPTION
Hello ! 
This pull request contains two things that I needed while I was using goxel. Would be nice to have it in the master too ! 
- Drag&drop: I was using multiple files(over 10). Opening them 1-by-1 was taking so long. Added drag and drop support. 
- While trying to import qb, I was by mistake selecting other types, and the program was acting like memory leak(the computer was stucking for a few minutes then goxel crushes). So added a qb file check. 

Looking forward to hear for any suggestions of these, or maybe merging :) 

Best regards,

 