### PR TITLE
Sort input file list

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -136,4 +136,4 @@ env.Append(
     LINKFLAGS=os.environ.get("LDFLAGS", "").split()
 )
 
-env.Program(target='goxel', source=sources)
+env.Program(target='goxel', source=sorted(sources))


### PR DESCRIPTION
Sort input file list
so that goxel builds in a reproducible way
in spite of indeterministic filesystem readdir order
and http://bugs.python.org/issue30461

(without this patch there were variations in `/usr/bin/goxel` machine code)

See https://reproducible-builds.org/ for why this is good.

This PR was done while working on [reproducible builds for openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds).