### PR TITLE
Fix image plane to mesh conversion

### DIFF
--- a/doc/cla/individual/ravencgg.md
+++ b/doc/cla/individual/ravencgg.md
@@ -1,0 +1,11 @@
+United States, 2021-06-04
+
+I hereby agree to the terms of the Goxel Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Chris Genova raven.cgg@gmail.com https://github.com/ravencgg

--- a/src/image.c
+++ b/src/image.c
@@ -679,7 +679,7 @@ uint32_t image_get_key(const image_t *img)
 static void image_image_layer_to_mesh(image_t *img, layer_t *layer)
 {
     uint8_t *data;
-    int i, j, w, h, bpp = 0, pos[3];
+    int x, y, w, h, bpp = 0, pos[3];
     uint8_t c[4];
     float p[3];
     assert(img);
@@ -689,16 +689,16 @@ static void image_image_layer_to_mesh(image_t *img, layer_t *layer)
     image_history_push(img);
     data = img_read(layer->image->path, &w, &h, &bpp);
     acc = mesh_get_accessor(layer->mesh);
-    for (j = 0; j < w; j++)
-    for (i = 0; i < h; i++) {
-        vec3_set(p, i / (float)h - 0.5, 0.5 - j / (float)w, 0);
+    for (y = 0; y < h; y++)
+    for (x = 0; x < w; x++) {
+        vec3_set(p, 0.5 - x / (float)w, 1.0 - (y / (float)h) - 0.5, 0);
         mat4_mul_vec3(layer->mat, p, p);
         pos[0] = round(p[0]);
         pos[1] = round(p[1]);
         pos[2] = round(p[2]);
         memset(c, 0, 4);
         c[3] = 255;
-        memcpy(c, data + (j * w + i) * bpp, bpp);
+        memcpy(c, data + (y * w + x) * bpp, bpp);
         mesh_set_at(layer->mesh, &acc, pos, c);
     }
     texture_delete(layer->image);

--- a/src/image.c
+++ b/src/image.c
@@ -691,7 +691,7 @@ static void image_image_layer_to_mesh(image_t *img, layer_t *layer)
     acc = mesh_get_accessor(layer->mesh);
     for (y = 0; y < h; y++)
     for (x = 0; x < w; x++) {
-        vec3_set(p, 0.5 - x / (float)w, 1.0 - (y / (float)h) - 0.5, 0);
+        vec3_set(p, (x / (float)w) - 0.5, - ((y + 1) / (float)h) + 0.5, 0);
         mat4_mul_vec3(layer->mat, p, p);
         pos[0] = round(p[0]);
         pos[1] = round(p[1]);


### PR DESCRIPTION
Fixes a crash in the memcpy on non-square images.
Fixes the orientation and placement of the mesh.