### PR TITLE
Use an uppercase letter for the Goxel desktop shortcut

### DIFF
--- a/snap/gui/goxel.desktop
+++ b/snap/gui/goxel.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Version=1.0
 Encoding=UTF-8
-Name=goxel
+Name=Goxel
 GenericName=Voxel graphics editor
 Comment=3D Voxel Editor
 Exec=goxel


### PR DESCRIPTION
This change gives a more uniform look when viewing the menu of available applications on Linux.