### PR TITLE
Fix parallel build on all platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Build Goxel
         run: |
-          scons -j 4 mode=release
+          make release
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v3
@@ -83,7 +83,7 @@ jobs:
 
     - name: Build
       run: |
-        scons -j 4 mode=release
+        make release
 
     - name: Upload Artifacts
       uses: actions/upload-artifact@v3

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,20 @@
 SHELL = bash
-MAKEFLAGS+="-j $(shell nproc)"
+ifeq ($(OS),Linux)
+	JOBS := "-j $(shell nproc)"
+else
+	JOBS := "-j $(shell getconf _NPROCESSORS_ONLN)"
+endif
+
 .ONESHELL:
 
 all:
-	scons
+	scons $(JOBS)
 
 release:
-	scons mode=release
+	scons $(JOBS) mode=release
 
 profile:
-	scons mode=profile
+	scons $(JOBS) mode=profile
 
 run:
 	./goxel


### PR DESCRIPTION
https://stackoverflow.com/a/7045431/2278742
https://stackoverflow.com/questions/2527496/how-can-i-write-a-makefile-to-auto-detect-and-parallelize-the-build-with-gnu-mak#comment51509939_7045431

Now the CI log shows the following:

[windows_x86_64](https://github.com/Alexander-Wilms/goxel/actions/runs/7513436066/job/20455186036#logs)
```
Run make release
scons "-j 4" mode=release
```

[linux_x86_64](https://github.com/Alexander-Wilms/goxel/actions/runs/7513436066/job/20455185960#logs)
```
Run make release
scons "-j 4" mode=release
```

[osx_x86_64](https://github.com/Alexander-Wilms/goxel/actions/runs/7513436066/job/20455186002#logs)
```
Run make release
scons "-j 3" mode=release
```

The Stackoverflow answer linked above also recommends
```
# Only take half as many processors as available
NUMPROC := $(shell echo "$(NUMPROC)/2"|bc)
```
but since the build only takes a minute, I think that's not necessary.