### PR TITLE
Initialize graphics context in png_export

### DIFF
--- a/doc/cla/individual/madd-games.md
+++ b/doc/cla/individual/madd-games.md
@@ -1,0 +1,11 @@
+UK, 2024-03-18
+
+I hereby agree to the terms of the Goxel Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Mariusz Pilipczuk projekt.darma@gmail.com https://github.com/madd-games

--- a/src/formats/png.c
+++ b/src/formats/png.c
@@ -22,6 +22,10 @@
 // XXX: this function has to be rewritten.
 static int png_export(const image_t *img, const char *path, int w, int h)
 {
+    if (!goxel.graphics_initialized) {
+        goxel_create_graphics();
+    }
+
     uint8_t *buf;
     int bpp = img->export_transparent_background ? 4 : 3;
     if (!path) return -1;


### PR DESCRIPTION
Currently I get a segmentation fault on the following command:

```
goxel 0-colormap.vsp -e colormap.png
```

It turns out it's because `png_export()` calls for example `cache_get()` on `g_items_cache` which is `NULL`, because `render_init()` is never called. Normally when the GUI is initialized it gets called from `goxel_iter()` but this never happens with the `-e` option.

I have added this fix and confirmed it works in the `vsp` format which I added in my own branch. Unfortunately I cannot test this with imporing `.gox` because i get a different segmentation fault when i try `goxel test.gox -e test.png`, in the GOX importer, which I haven't figured out the cause of. But, it should be easy to see that we must initialize the renderer before we call `goxel_render_to_buf()`.