### PR TITLE
Minor documentation fixes

### DIFF
--- a/INTERNALS.md
+++ b/INTERNALS.md
@@ -7,16 +7,16 @@ implement a copy on write mechanism with references counting, so that it is
 very fast to copy blocks, the actual data (`block_data_t`) is copied only when
 we make change to a block.
 
-Several blocks together form a mesh (`mesh_t`), the meshes also use a copy on
-write mechanism to make copy basically free.
+Several blocks together form a volume (`volume_t`), the volumes also use a copy
+on write mechanism to make copy basically free.
 
-An `image_t` contains several `layer_t`, which is basically a mesh plus a few
+An `image_t` contains several `layer_t`, which is basically a volume plus a few
 attributes.  The image also keeps snapshots of the layers at every changes for
 undo history (since we use copy on write on individual blocks, this does not
 require much memory).
 
-The basic function to operate on a mesh is `mesh_op`, we give it a `painter_t`
-pointer that defines the operation: shape, color, mode, etc.
+The basic function to operate on a volume is `volume_op`, we give it a
+`painter_t` pointer that defines the operation: shape, color, mode, etc.
 
 All the rendering functions are differed.  The `render_xxx` calls just build a
 list of operations, that is executed when we call `render_render`.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Goxel
 =====
 
-Version 0.12.0
+Version 0.14.0
 
 By Guillaume Chereau <guillaume@noctua-software.com>
 


### PR DESCRIPTION
I noticed the explanation in `INTERNALS.md` is outdated and refers to "mesh" instead of "volume" as it is now, and the `README.md` was stating the incorrect version, so just a quick PR to fix that.