### PR TITLE
Load global scripts

### DIFF
--- a/src/script.c
+++ b/src/script.c
@@ -810,6 +810,12 @@ void script_init(void)
         LOG_I("Loading scripts from %s\n", dir);
         sys_list_dir(dir, on_user_script, NULL);
     }
+    
+    if (sys_get_global_dir()) {
+        snprintf(dir, sizeof(dir), "%s/scripts", sys_get_global_dir());
+        LOG_I("Loading scripts from %s\n", dir);
+        sys_list_dir(dir, on_user_script, NULL);
+    }
 }
 
 void script_release(void)

--- a/src/system.c
+++ b/src/system.c
@@ -56,10 +56,16 @@ static const char *get_user_dir_unix(void *user)
     return ret;
 }
 
+static const char *get_global_dir_unix(void *user)
+{
+    return "/etc/goxel";
+}
+
 static void init_unix(void) __attribute__((constructor));
 static void init_unix(void)
 {
     sys_callbacks.get_user_dir = get_user_dir_unix;
+    sys_callbacks.get_global_dir = get_global_dir_unix;
 }
 
 #endif
@@ -190,6 +196,19 @@ const char *sys_get_user_dir(void)
     if (sys_callbacks.get_user_dir)
         return sys_callbacks.get_user_dir(sys_callbacks.user);
     return get_user_dir_fallback();
+}
+
+/*
+ * Function: sys_get_global_dir
+ * Return the global config directory for goxel
+ *
+ * On linux, this should be $HOME/.config/goxel.
+ */
+const char *sys_get_global_dir(void)
+{
+    if (sys_callbacks.get_global_dir)
+        return sys_callbacks.get_global_dir(sys_callbacks.user);
+    return NULL;
 }
 
 const char *sys_get_clipboard_text(void* user)

--- a/src/system.c
+++ b/src/system.c
@@ -202,7 +202,7 @@ const char *sys_get_user_dir(void)
  * Function: sys_get_global_dir
  * Return the global config directory for goxel
  *
- * On linux, this should be $HOME/.config/goxel.
+ * On linux, this should be /etc/goxel.
  */
 const char *sys_get_global_dir(void)
 {

--- a/src/system.h
+++ b/src/system.h
@@ -38,6 +38,7 @@ typedef struct {
     void (*log)(void *user, const char *msg);
     void (*set_window_title)(void *user, const char *title);
     const char *(*get_user_dir)(void *user);
+    const char *(*get_global_dir)(void *user);
     const char *(*get_clipboard_text)(void* user);
     void (*set_clipboard_text)(void *user, const char *text);
     void (*show_keyboard)(void *user, bool has_text);
@@ -91,6 +92,14 @@ int sys_delete_file(const char *path);
  * On linux, this should be $HOME/.config/goxel.
  */
 const char *sys_get_user_dir(void);
+
+/*
+ * Function: sys_get_global_dir
+ * Return the global config directory for goxel
+ *
+ * On linux, this should be /etc/goxel.
+ */
+const char *sys_get_global_dir(void);
 
 /*
  * Function: sys_make_dir


### PR DESCRIPTION
Here is my proposal for a system-wide script directory, in additional to the user directory which we already use.

Currently I've set it to `/etc/goxel/scripts` on Linux, and I'm not sure what it could be on Windows.

This would allow scripts to be installed globally, for example via a Debian package, allowing packages to add fuctionality such as additional import/export formats. So far it was possible to install scripts for a given user but not as part of a package installed on the system.

Let me know what you think