### PR TITLE
Add the clangd cache to the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ xcuserdata/
 /.vimrc
 /compile_commands.json
 /TAGS
+/.cache


### PR DESCRIPTION
`clangd` reads the `/compile_commands.json` file and provides IDEs such as VSCode with features like "go to definition", "find all references", hints, etc. It creates a directory called `.cache` in the package root, and unfortuantely that's picked up by git, which means that when I try to work on the project in VSCode, it asks me to commit all of these cache files. `clangd` can be (and is) used by other IDEs as well, so it will help with those too; though I do not have experience with others.