### PR TITLE
Add ruler to show the line limit in VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.rulers": [80]
+}


### PR DESCRIPTION
Thanks to this change if you open the project in VSCode, you will see a vertical line that shows on the 80th character, allowing you to see the limit as described in `CONTRUBITING.md`.