### PR TITLE
Add ability to open multiple filter windows

### DIFF
--- a/src/filters.c
+++ b/src/filters.c
@@ -22,13 +22,18 @@
 // stb array of registered filters.
 static filter_t **g_filters = NULL;
 
-static void a_filter_open(void *data)
+static void a_filter_toggle(void *data)
 {
     filter_t *filter = data;
-    LOG_D("Open filter %s", filter->name);
-    goxel.gui.current_filter = (filter_t*)data;
-    if (filter->on_open) {
+    LOG_D("Toggle filter %s", filter->name);
+    filter->is_open = !filter->is_open;
+
+    if (filter->is_open && filter->on_open) {
         filter->on_open(filter);
+    }
+
+    if (!filter->is_open && filter->on_close) {
+        filter->on_close(filter);
     }
 }
 
@@ -38,7 +43,7 @@ void filter_register_(filter_t *filter)
     action = (action_t) {
         .id = filter->action_id,
         .default_shortcut = filter->default_shortcut,
-        .cfunc_data = a_filter_open,
+        .cfunc_data = a_filter_toggle,
         .data = (void*)filter,
         .flags = ACTION_CAN_EDIT_SHORTCUT,
     };
@@ -48,7 +53,7 @@ void filter_register_(filter_t *filter)
 
 
 void filters_iter_all(
-        void *arg, void (*f)(void *arg, const filter_t *filter))
+        void *arg, void (*f)(void *arg, filter_t *filter))
 {
     int i;
     for (i = 0; i < arrlen(g_filters); i++) {

--- a/src/filters.h
+++ b/src/filters.h
@@ -19,6 +19,8 @@
 #ifndef FILTERS_H
 #define FILTERS_H
 
+#include <stdbool.h>
+
 typedef struct filter filter_t;
 
 struct filter {
@@ -28,6 +30,7 @@ struct filter {
     const char *name;
     const char *action_id;
     const char *default_shortcut;
+    bool is_open;
 };
 
 #define FILTER_REGISTER(id_, klass_, ...) \
@@ -47,6 +50,6 @@ void filter_register_(filter_t *filter);
  * Iter all the registered filters
  */
 void filters_iter_all(
-        void *arg, void (*f)(void *arg, const filter_t *filter));
+        void *arg, void (*f)(void *arg, filter_t *filter));
 
 #endif // FILTERS_H

--- a/src/goxel.h
+++ b/src/goxel.h
@@ -553,7 +553,6 @@ typedef struct goxel
         int current_panel; // Index of the current visible control panel.
         float panel_width;
         float viewport[4];
-        filter_t *current_filter;
     } gui;
 
     char **recent_files; // stb arraw of most recently used files.

--- a/src/gui/menu.c
+++ b/src/gui/menu.c
@@ -71,7 +71,7 @@ static void on_script(void *user, const char *name)
         script_execute(name);
 }
 
-static void on_filter(void *user, const filter_t *filter)
+static void on_filter(void *user, filter_t *filter)
 {
     const action_t *action;
     if (gui_menu_item(0, filter->name, true)) {


### PR DESCRIPTION
The filter windows now open with a "cascading" layout and you can have multiple open. They also open to the right of the default panel window, making it a bit more friendly. They are all detached.