### PR TITLE
Rework File -> Export menu option

### DIFF
--- a/src/gui.h
+++ b/src/gui.h
@@ -153,6 +153,8 @@ bool gui_is_item_deactivated(void);
 
 void gui_query_quit(void);
 
+void gui_open_export_panel(void);
+
 enum {
     GUI_POPUP_FULL      = 1 << 0,
     GUI_POPUP_RESIZE    = 1 << 1,

--- a/src/gui/app.c
+++ b/src/gui/app.c
@@ -114,6 +114,11 @@ static void on_click(void) {
         sound_play("click", 1.0, 1.0);
 }
 
+void gui_open_export_panel(void)
+{
+    goxel.gui.current_panel = PANEL_EXPORT;
+}
+
 static void render_left_panel(void)
 {
     int i;

--- a/src/gui/menu.c
+++ b/src/gui/menu.c
@@ -59,12 +59,6 @@ static void import_menu_callback(void *user, file_format_t *f)
     goxel_import_file(NULL, f->name);
 }
 
-static void export_menu_callback(void *user, file_format_t *f)
-{
-    if (gui_menu_item(0, f->name, true))
-        goxel_export_to_file(NULL, f->name);
-}
-
 static void on_script(void *user, const char *name)
 {
     if (gui_menu_item(0, name, true))
@@ -120,9 +114,8 @@ void gui_menu(void)
             gui_menu_item(ACTION_overwrite_export, overwrite_export_label,
                           true);
         }
-        if (gui_menu_begin(_("Export"), true)) {
-            file_format_iter("w", NULL, export_menu_callback);
-            gui_menu_end();
+        if (gui_menu_item(0, _("Export"), true)) {
+            gui_open_export_panel();
         }
         gui_menu_item(ACTION_quit, _("Quit"), true);
         gui_menu_end();


### PR DESCRIPTION
Currently there are 2 ways of exporting files from Goxel. One is to click `File -> Export -> File Type` which directly exports a file and the other is by opening the export window by clicking the export button in the toolbar which then exposes export options.

Having 2 ways of exporting is confusing so I've adjusted File -> Export to just open the export window so that users don't miss that some file types have additional export options. 