### PR TITLE
Fix for unidentified GLEW methods when compiling a build on Windows

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -112,7 +112,7 @@ if target_os == 'posix':
 
 
 # Windows compilation support.
-if target_os == 'msys':
+if target_os == 'msys' or target_os == 'cygwin':
     env.Append(CXXFLAGS=['-Wno-attributes', '-Wno-unused-variable',
                          '-Wno-unused-function'])
     env.Append(CCFLAGS=['-Wno-error=address']) # To remove if possible.


### PR DESCRIPTION
Also please mention the two missing packages on the pain page:
mingw-w64-x86_64-glew
mingw-w64-x86_64-libpng