### PR TITLE
Persist the UI layout across sessions

### DIFF
--- a/src/goxel.h
+++ b/src/goxel.h
@@ -554,9 +554,16 @@ typedef struct goxel
         float panel_width;
         float viewport[4];
         margins_t safe_margins;
+        bool reset_layout; // For one frame: force windows to default position.
     } gui;
 
     char **recent_files; // stb arraw of most recently used files.
+
+    // Persisted OS window geometry (settings.ini [window]).  On Wayland the
+    // position cannot be set by the client, so only size + maximized state
+    // are restored.
+    int window_size[2];     // 0 = not saved yet.
+    bool window_maximized;
 
     const char *lang; // Current set language.
 

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -437,7 +437,14 @@ static void init_ImGui(void)
     ImGui::CreateContext();
     ImGuiIO& io = ImGui::GetIO();
     io.DeltaTime = 1.0f/60.0f;
-    io.IniFilename = NULL;
+
+    // Enable imgui.ini so window state persists across sessions (used for the
+    // detached panels and filter windows).  Windows placed with
+    // ImGuiCond_Always still get their position/size forced every frame, so
+    // the fixed layout is unaffected by the stored values.
+    static char ini_path[1024];
+    snprintf(ini_path, sizeof(ini_path), "%s/imgui.ini", sys_get_user_dir());
+    io.IniFilename = ini_path;
 
     io.KeyMap[ImGuiKey_Tab]         = KEY_TAB;
     io.KeyMap[ImGuiKey_LeftArrow]   = KEY_LEFT;
@@ -850,9 +857,22 @@ int gui_window_begin(const char *label, float x, float y, float w, float h,
         win_flags |= ImGuiWindowFlags_NoMouseInputs;
     if (dir == 0)
         win_flags |= ImGuiWindowFlags_HorizontalScrollbar;
-    ImGui::SetNextWindowPos(ImVec2(x, y),
-            (flags & GUI_WINDOW_MOVABLE) ?
-            ImGuiCond_Appearing : ImGuiCond_Always);
+    // Position handling:
+    //  - reset_layout: force the default (x, y) for one frame.
+    //  - PERSIST windows (detached panels, filters): FirstUseEver so a
+    //    position restored from imgui.ini wins and user moves are kept.
+    //  - other movable windows (docked panel): Appearing, so they snap back
+    //    to their slot each time they open but can still be dragged to detach.
+    ImGuiCond pos_cond;
+    if (goxel.gui.reset_layout)
+        pos_cond = ImGuiCond_Always;
+    else if (flags & GUI_WINDOW_PERSIST)
+        pos_cond = ImGuiCond_FirstUseEver;
+    else if (flags & GUI_WINDOW_MOVABLE)
+        pos_cond = ImGuiCond_Appearing;
+    else
+        pos_cond = ImGuiCond_Always;
+    ImGui::SetNextWindowPos(ImVec2(x, y), pos_cond);
     ImGui::SetNextWindowSize(ImVec2(w, h));
 
     key = ImGui::GetID("last_pos");
@@ -1727,6 +1747,17 @@ void gui_push_id(const char *id)
 void gui_pop_id(void)
 {
     ImGui::PopID();
+}
+
+// Purge all the window positions/sizes remembered by ImGui (both the stored
+// settings and the live windows), so a layout reset does not restore stale
+// positions when windows reopen.
+void gui_clear_window_settings(void)
+{
+    ImGuiContext& g = *ImGui::GetCurrentContext();
+    for (int i = 0; i < g.Windows.Size; i++)
+        ImGui::ClearWindowSettings(g.Windows[i]->Name);
+    ImGui::ClearIniSettings();
 }
 
 void gui_request_panel_width(float width)

--- a/src/gui.h
+++ b/src/gui.h
@@ -34,6 +34,9 @@
 enum {
     GUI_WINDOW_MOVABLE                  = 1 << 0,
     GUI_WINDOW_HORIZONTAL               = 1 << 1, // For scrolling.
+    // Persist the window position across sessions (via imgui.ini). Without it
+    // a movable window snaps back to its default position each time it opens.
+    GUI_WINDOW_PERSIST                  = 1 << 3,
 
     // Return flags.
     GUI_WINDOW_MOVED                    = 1 << 2,
@@ -214,5 +217,16 @@ void gui_list(const gui_list_t *list);
 float gui_get_current_pos_x(void);
 void gui_set_current_pos_x(float x);
 float gui_get_item_height(void);
+
+/*
+ * Layout persistence (saved in settings.ini, [layout] section).
+ * Panel names are the untranslated ids from the PANELS table.
+ */
+const char *gui_layout_current_panel(void);
+int gui_layout_detached_panels(const char **out, int max);
+void gui_layout_set_current_panel(const char *name);
+void gui_layout_set_panel_detached(const char *name);
+void gui_layout_reset(void);
+void gui_clear_window_settings(void);
 
 #endif // GUI_H

--- a/src/gui/app.c
+++ b/src/gui/app.c
@@ -109,6 +109,87 @@ struct filter_layout_state {
     int next_y;
 };
 
+// --- Layout persistence -----------------------------------------------------
+
+static int panel_index_by_name(const char *name)
+{
+    int i;
+    for (i = 1; i < (int)ARRAY_SIZE(PANELS); i++) {
+        if (PANELS[i].name && strcmp(PANELS[i].name, name) == 0)
+            return i;
+    }
+    return 0;
+}
+
+const char *gui_layout_current_panel(void)
+{
+    if (!goxel.gui.current_panel) return NULL;
+    return PANELS[goxel.gui.current_panel].name;
+}
+
+int gui_layout_detached_panels(const char **out, int max)
+{
+    int i, n = 0;
+    for (i = 1; i < (int)ARRAY_SIZE(PANELS) && n < max; i++) {
+        if (PANELS[i].detached && PANELS[i].name)
+            out[n++] = PANELS[i].name;
+    }
+    return n;
+}
+
+void gui_layout_set_current_panel(const char *name)
+{
+    goxel.gui.current_panel = panel_index_by_name(name);
+}
+
+void gui_layout_set_panel_detached(const char *name)
+{
+    int i = panel_index_by_name(name);
+    if (i) PANELS[i].detached = true;
+}
+
+void gui_layout_reset(void)
+{
+    char path[1024];
+    int i;
+
+    goxel.gui.current_panel = 0;
+    for (i = 0; i < (int)ARRAY_SIZE(PANELS); i++)
+        PANELS[i].detached = false;
+    goxel.gui.reset_layout = true;
+    gui_clear_window_settings();
+    snprintf(path, sizeof(path), "%s/imgui.ini", sys_get_user_dir());
+    remove(path);
+    // settings.ini is rewritten by save_layout_if_changed() at the end of the
+    // frame, once it sees the layout changed.
+}
+
+// Save the layout to settings.ini when it changed since the last frame.
+static void save_layout_if_changed(void)
+{
+    static int last_panel = -1;
+    static uint32_t last_detached = 0;
+    uint32_t detached = 0;
+    int i;
+
+    // The detached state is tracked as a bitmask, one bit per panel.
+    _Static_assert(ARRAY_SIZE(PANELS) <= 32, "too many panels for the bitmask");
+    for (i = 1; i < (int)ARRAY_SIZE(PANELS); i++)
+        if (PANELS[i].detached) detached |= (1u << i);
+
+    if (last_panel == -1) {
+        // First frame: adopt the just-restored state without saving it.
+        last_panel = goxel.gui.current_panel;
+        last_detached = detached;
+        return;
+    }
+    if (goxel.gui.current_panel == last_panel && detached == last_detached)
+        return;
+    last_panel = goxel.gui.current_panel;
+    last_detached = detached;
+    settings_save();
+}
+
 static void on_click(void) {
     if (DEFINED(GUI_SOUND))
         sound_play("click", 1.0, 1.0);
@@ -117,13 +198,26 @@ static void on_click(void) {
 static void render_left_panel(void)
 {
     int i;
-    bool selected;
+    bool active, selected;
 
     for (i = 1; i < (int)ARRAY_SIZE(PANELS); i++) {
-        selected = (goxel.gui.current_panel == i);
+        if (!PANELS[i].name) continue;
+        // A panel is "active" (button highlighted) when it is visible, either
+        // docked or as a detached floating window.
+        active = (goxel.gui.current_panel == i) || PANELS[i].detached;
+        selected = active;
         if (gui_tab(tr(PANELS[i].name), PANELS[i].icon, &selected)) {
             on_click();
-            goxel.gui.current_panel = selected ? i : 0;
+            if (active) {
+                // Toggle off: close the docked panel or the detached window.
+                if (goxel.gui.current_panel == i)
+                    goxel.gui.current_panel = 0;
+                PANELS[i].detached = false;
+            } else {
+                // Open docked, replacing any other docked panel.
+                goxel.gui.current_panel = i;
+                PANELS[i].detached = false;
+            }
         }
     }
 }
@@ -171,7 +265,8 @@ static void gui_filter_window(void *arg, filter_t *filter)
 
     if (filter->is_open) {
         gui_window_begin(filter->name, state->next_x, state->next_y,
-                            goxel.gui.panel_width, 0, GUI_WINDOW_MOVABLE);
+                            goxel.gui.panel_width, 0,
+                            GUI_WINDOW_MOVABLE | GUI_WINDOW_PERSIST);
 
         if (gui_panel_header(filter->name)) {
             if (filter->on_close) {
@@ -195,6 +290,7 @@ void gui_app(void)
     const float spacing = 8;
     int flags;
     int i;
+    char win_id[128];
     filter_layout_state_t filter_layout_state;
     const float item_height = gui_get_item_height();
 
@@ -222,8 +318,12 @@ void gui_app(void)
 
     if (goxel.gui.current_panel) {
         name = tr(PANELS[goxel.gui.current_panel].name);
+        // Use a language independent window id (### suffix) so imgui.ini keeps
+        // matching the window across UI language changes.
+        snprintf(win_id, sizeof(win_id), "%s###%s", name,
+                 PANELS[goxel.gui.current_panel].name);
         flags = gui_window_begin(
-                name, x, y, goxel.gui.panel_width, 0, GUI_WINDOW_MOVABLE);
+                win_id, x, y, goxel.gui.panel_width, 0, GUI_WINDOW_MOVABLE);
         if (gui_panel_header(name))
             goxel.gui.current_panel = 0;
         else
@@ -239,8 +339,9 @@ void gui_app(void)
     for (i = 0; i < ARRAY_SIZE(PANELS); i++) {
         if (!PANELS[i].detached) continue;
         name = tr(PANELS[i].name);
-        gui_window_begin(name, 0, 0, goxel.gui.panel_width, 0,
-                         GUI_WINDOW_MOVABLE);
+        snprintf(win_id, sizeof(win_id), "%s###%s", name, PANELS[i].name);
+        gui_window_begin(win_id, 0, 0, goxel.gui.panel_width, 0,
+                         GUI_WINDOW_MOVABLE | GUI_WINDOW_PERSIST);
         if (gui_panel_header(name)) {
             PANELS[i].detached = false;
         }
@@ -258,4 +359,7 @@ void gui_app(void)
          PANELS[PANEL_RENDER].detached);
 
     gui_view_cube(goxel.gui.viewport[2] - 128, item_height + 2, 128, 128);
+
+    save_layout_if_changed();
+    goxel.gui.reset_layout = false;
 }

--- a/src/gui/menu.c
+++ b/src/gui/menu.c
@@ -147,6 +147,8 @@ void gui_menu(void)
         gui_menu_item(ACTION_view_toggle_ortho,
                 cam->ortho ? _("Perspective") : _("Orthographic"), true);
         gui_menu_item(ACTION_view_default, _("Reset"), true);
+        if (gui_menu_item(0, _("Reset windows"), true))
+            gui_layout_reset();
         gui_menu_end();
     }
     if (gui_menu_begin("Filters", true)) { // Note: to translate.

--- a/src/gui/settings.c
+++ b/src/gui/settings.c
@@ -240,6 +240,7 @@ static int settings_ini_handler(void *user, const char *section,
                                 int lineno)
 {
     action_t *a;
+    char buf[256], *tok;
     if (strcmp(section, "ui") == 0) {
         if (strcmp(name, "theme") == 0) {
             theme_set(value);
@@ -268,6 +269,24 @@ static int settings_ini_handler(void *user, const char *section,
             if (strcmp(value, "alt") == 0) {
                 goxel.emulate_three_buttons_mouse = KEY_LEFT_ALT;
             }
+        }
+    }
+    if (strcmp(section, "window") == 0) {
+        if (strcmp(name, "width") == 0)
+            goxel.window_size[0] = atoi(value);
+        if (strcmp(name, "height") == 0)
+            goxel.window_size[1] = atoi(value);
+        if (strcmp(name, "maximized") == 0)
+            goxel.window_maximized = atoi(value);
+    }
+    if (strcmp(section, "layout") == 0) {
+        if (strcmp(name, "panel") == 0) {
+            gui_layout_set_current_panel(value);
+        }
+        if (strcmp(name, "detached") == 0) {
+            snprintf(buf, sizeof(buf), "%s", value);
+            for (tok = strtok(buf, ","); tok; tok = strtok(NULL, ","))
+                gui_layout_set_panel_detached(tok);
         }
     }
     return 0;
@@ -335,6 +354,9 @@ void settings_save(void)
 {
     char path[1024];
     FILE *file;
+    const char *panel;
+    const char *detached[32];
+    int i, n;
 
     snprintf(path, sizeof(path), "%s/settings.ini", sys_get_user_dir());
     LOG_I("Save settings to %s", path);
@@ -348,6 +370,26 @@ void settings_save(void)
     fprintf(file, "theme=%s\n", theme_get()->name);
     fprintf(file, "language=%s\n", goxel.lang);
     fprintf(file, "scale=%f\n", gui_get_scale());
+    fprintf(file, "\n");
+
+    if (goxel.window_size[0] > 0 || goxel.window_maximized) {
+        fprintf(file, "[window]\n");
+        fprintf(file, "width=%d\n", goxel.window_size[0]);
+        fprintf(file, "height=%d\n", goxel.window_size[1]);
+        fprintf(file, "maximized=%d\n", goxel.window_maximized ? 1 : 0);
+        fprintf(file, "\n");
+    }
+
+    panel = gui_layout_current_panel();
+    n = gui_layout_detached_panels(detached, 32);
+    fprintf(file, "[layout]\n");
+    if (panel) fprintf(file, "panel=%s\n", panel);
+    if (n) {
+        fprintf(file, "detached=");
+        for (i = 0; i < n; i++)
+            fprintf(file, "%s%s", i ? "," : "", detached[i]);
+        fprintf(file, "\n");
+    }
     fprintf(file, "\n");
 
     fprintf(file, "[shortcuts]\n");

--- a/src/main.c
+++ b/src/main.c
@@ -185,6 +185,15 @@ static void loop_function(void *arg)
 
     glfwGetWindowSize(window, &win_size[0], &win_size[1]);
     glfwGetFramebufferSize(window, &fb_size[0], &fb_size[1]);
+
+    // Keep track of the window geometry so it can be persisted on exit. Only
+    // record the size while not maximized, so the maximized state restores to
+    // the previous floating size. Skipped when iconified (handled above).
+    goxel.window_maximized = glfwGetWindowAttrib(window, GLFW_MAXIMIZED);
+    if (!goxel.window_maximized) {
+        goxel.window_size[0] = win_size[0];
+        goxel.window_size[1] = win_size[1];
+    }
     monitor = glfwGetPrimaryMonitor();
     glfwGetMonitorContentScale(monitor, &scales[0], &scales[1]);
     scale = g_scale * scales[0];
@@ -226,6 +235,9 @@ static void start_main_loop(void (*func)(void *arg), GLFWwindow *window)
         func(window);
         if (goxel.quit) break;
     }
+    // Persist the window geometry (tracked each frame in loop_function) before
+    // destroying the window.
+    settings_save();
     glfwTerminate();
 }
 #else
@@ -422,6 +434,14 @@ int main(int argc, char **argv)
     glewInit();
 #endif
     goxel_init();
+
+    // Restore the saved window geometry (size + maximized state). The position
+    // is left to the window manager: on Wayland a client cannot set it.
+    if (goxel.window_maximized) {
+        glfwMaximizeWindow(window);
+    } else if (goxel.window_size[0] > 0) {
+        glfwSetWindowSize(window, goxel.window_size[0], goxel.window_size[1]);
+    }
 
     // Run the unit tests in debug.
     if (DEBUG) {


### PR DESCRIPTION
## What

Remembers the tool panels and the OS window geometry between runs.

## Why

Currently the tool panels always start closed and every window opens at a
default position, so the workspace has to be set up again on each launch
(`io.IniFilename` was disabled). This persists that state.

## How

- Save the open docked panel and the list of detached panels in
  `settings.ini` (`[layout]`), and enable ImGui's `imgui.ini` so the
  positions of detached panels and filter windows are restored. Movable
  windows use a language-independent id (`###`) so positions keep matching
  across UI language changes.
- Toolbar buttons now reflect the active state of their panel (docked or
  detached) and toggle it closed when clicked again — this makes a hidden
  window reachable again after resizing.
- Add a `View > Reset windows` entry that closes all panels and clears the
  saved positions.
- Persist the OS window size and maximized state (`main.c`). The window
  position is intentionally left to the window manager, as Wayland does not
  allow a client to set it.

## Notes

- The toolbar toggle is a small behavior change; happy to gate it or adjust
  if you'd prefer the previous click behavior.
- CLA signed in #460.

## Testing

Built on Fedora 44 (clang), exercised on GNOME/Wayland: opened/detached/moved
panels, resized and maximized the window, quit and relaunched — layout and
geometry restored. `Reset windows` returns everything to defaults.