### PR TITLE
Match keyboard shortcuts by key label, not physical position

### DIFF
--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -540,8 +540,12 @@ static int check_action_shortcut(action_t *action, void *user)
     if (str_startswith(s, "Ctrl")) return 0;
     if (str_startswith(s, "Shift")) return 0;
 
+    // Match by the printed label of the key (layout-aware) rather than its
+    // physical position, so combos like Ctrl+Z land on the key labelled 'Z'
+    // even on non-QWERTY layouts (AZERTY...).
+    int key = sys_get_key_for_char(s[0]);
     if (    (check_char && isCharPressed(s[0])) ||
-            (check_key && ImGui::IsKeyPressed((ImGuiKey)s[0], false))) {
+            (check_key && ImGui::IsKeyPressed((ImGuiKey)key, false))) {
         action_exec(action);
         return 1;
     }

--- a/src/main.c
+++ b/src/main.c
@@ -289,6 +289,37 @@ static void set_clipboard_text(void *user, const char *text)
     glfwSetClipboardString(window, text);
 }
 
+static int get_key_for_char(void *user, int c)
+{
+    // Lazily build a map from printed label to GLFW key code for the current
+    // keyboard layout, so shortcuts follow the labels of the keys (e.g. Ctrl+Z
+    // hits the key printed 'Z', not the physical QWERTY position, on AZERTY).
+    // Note: computed once; a layout change during the session is not picked up.
+    static int char_to_key[128];
+    static bool built = false;
+    int i;
+    const char *name;
+    unsigned char ch;
+
+    if (!built) {
+        for (i = 0; i < 128; i++) char_to_key[i] = -1;
+        // Only the printable ASCII keys (up to the grave accent); this skips
+        // the keypad, so a digit shortcut maps to the main row, not the pad.
+        for (i = GLFW_KEY_SPACE; i <= GLFW_KEY_GRAVE_ACCENT; i++) {
+            name = glfwGetKeyName(i, 0);
+            if (!name || !name[0] || (unsigned char)name[0] >= 128) continue;
+            ch = name[0];
+            if (ch >= 'A' && ch <= 'Z') ch += 'a' - 'A';
+            if (char_to_key[ch] == -1) char_to_key[ch] = i;
+        }
+        built = true;
+    }
+
+    if (c < 0 || c >= 128) return -1;
+    if (c >= 'A' && c <= 'Z') c += 'a' - 'A';
+    return char_to_key[c];
+}
+
 static void filters_to_nfd_spec(
         const char *const *filters, char buf[], size_t buf_size)
 {
@@ -379,6 +410,7 @@ int main(int argc, char **argv)
     sys_callbacks.set_window_title = set_window_title;
     sys_callbacks.get_clipboard_text = get_clipboard_text;
     sys_callbacks.set_clipboard_text = set_clipboard_text;
+    sys_callbacks.get_key_for_char = get_key_for_char;
     sys_callbacks.open_dialog = open_dialog;
     parse_options(argc, argv, &args);
 

--- a/src/system.c
+++ b/src/system.c
@@ -212,6 +212,19 @@ void sys_show_keyboard(bool has_text)
 }
 
 /*
+ * Function: sys_get_key_for_char
+ * Map a printed character to the key code that produces it on the current
+ * keyboard layout.
+ */
+int sys_get_key_for_char(int c)
+{
+    int ret;
+    if (!sys_callbacks.get_key_for_char) return c;
+    ret = sys_callbacks.get_key_for_char(sys_callbacks.user, c);
+    return ret >= 0 ? ret : c;
+}
+
+/*
  * Function: sys_save_to_photos
  * Save a png file to the system photo album.
  */

--- a/src/system.h
+++ b/src/system.h
@@ -40,6 +40,11 @@ typedef struct {
     const char *(*get_clipboard_text)(void* user);
     void (*set_clipboard_text)(void *user, const char *text);
     void (*show_keyboard)(void *user, bool has_text);
+    // Return the key code (GLFW/USB HID like, indexing inputs_t.keys) whose
+    // printed label matches the given ascii character on the current keyboard
+    // layout, or -1 if unknown.  Lets shortcuts follow the printed label of
+    // the keys instead of their physical position (e.g. Ctrl+Z on AZERTY).
+    int (*get_key_for_char)(void *user, int c);
     void (*save_to_photos)(void *user, const uint8_t *data, int size,
                            void (*on_finished)(int r));
     int (*iter_paths)(void *user, int location, int options, const char *name,
@@ -161,6 +166,15 @@ void sys_set_window_title(const char *title);
  * Show a virtual keyboard if needed.
  */
 void sys_show_keyboard(bool has_text);
+
+/*
+ * Function: sys_get_key_for_char
+ * Return the key code (as used in inputs_t.keys) whose printed label matches
+ * the given ascii character on the current keyboard layout, or the character
+ * itself if the layout mapping is unavailable.  Used to make keyboard
+ * shortcuts follow the label of the keys rather than their physical position.
+ */
+int sys_get_key_for_char(int c);
 
 /*
  * Function: sys_save_to_photo


### PR DESCRIPTION
Keyboard shortcuts were matched against the physical position of the keys — goxel reads GLFW key codes, which follow a US QWERTY layout — so combos like Ctrl+Z landed on the wrong key on non-QWERTY layouts. On an AZERTY keyboard, undo required pressing Ctrl+W, because the physical Z position there is labelled W.

This adds a `sys_get_key_for_char()` helper, backed by a new `get_key_for_char` system callback implemented with `glfwGetKeyName()`, which maps a printed character to the key that produces it on the current layout. The GUI shortcut check now translates the shortcut character through it before matching, so shortcuts follow the printed label of the keys.

QWERTY is unaffected (labels match positions there). Known limits: digit shortcuts on layouts where digits need a modifier still fall back to position, and a layout change mid-session is not picked up.

Tested on Fedora / Wayland with an AZERTY layout: Ctrl+Z/Y, Ctrl+C/V and the single-key tool shortcuts all land on the labelled keys.